### PR TITLE
Define testing conventions for feature code

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,110 @@
+# Testing conventions
+
+Stack: Vitest + jsdom + Testing Library (`vitest.config.ts`, `src/test/setup.ts`).
+
+## What gets tested
+
+- **Every feature component gets a render test** — mount it with realistic
+  props/fragment data and assert on what a user would see.
+- **Critical interactions get a behavior test** — clicks, form submits, and
+  conditional branches that change what's on screen (loading states, empty
+  states, error states). Not every prop combination needs its own test; cover
+  the paths that matter to the user, not every branch in the code.
+- Use `userEvent`, not `fireEvent`, for interactions — it simulates the full
+  event sequence a real user triggers (focus → mousedown → mouseup → click),
+  not just a single synthetic event.
+- Query by role/label/text (`screen.getByRole`, etc.), not `data-testid`.
+  Reaching for a test ID is a sign the component itself isn't accessible —
+  fix that first.
+- **Pure functions and hooks get plain tests, no Testing Library.** Not
+  everything in a feature directory is a component (e.g.
+  `recipe-card/utils.ts`) — a plain `it`/`expect` against the exported
+  function is enough. No `render`, no `MockedProvider`. Same co-location
+  rule applies: `utils.ts` → `utils.test.ts`.
+
+## Guidance for AI-authored tests
+
+Most of these tests will be written by an AI assistant. The failure modes
+worth guarding against are different from the ones a human writing their own
+tests runs into:
+
+- **No tautological tests.** Don't write the implementation, then write a
+  test that asserts whatever that implementation happens to do — it'll pass
+  immediately and prove nothing. A test should assert the behavior implied
+  by the ticket/spec, independent of how it got implemented. If a test can't
+  fail given a plausible bug, it isn't testing anything.
+- **A render test asserts specific visible content, not just "didn't
+  throw."** `render(<Foo />)` with no further assertion (or a bare
+  `toBeTruthy()` on the container) satisfies "every component gets a render
+  test" on paper while checking nothing. Assert an actual name, label, role,
+  or piece of text.
+- **Realistic, typed mock data.** Type fragment/mutation literals against
+  the generated `XFragment`/`XMutation` types rather than casting through
+  `any`, and use plausible values, not `"test"` / `"foo"` everywhere. Loose
+  mocks let a test pass while masking a real shape mismatch.
+- **A test must be run and shown passing before it's considered done.**
+  Don't hand off an assertion that looks plausible but was never executed —
+  run `pnpm test` (and check the specific new test actually ran, not just
+  that the suite was green) before calling the work finished.
+
+## Mocking GraphQL
+
+Two situations, two approaches:
+
+**Component takes fragment data as a prop** (most presentational
+components — `RecipeCard`, `UserAvatar`, `PlanItem`) — no provider needed.
+Data masking means the generated `XFragment` type is really just the
+selection's plain object shape at runtime, so construct a literal matching
+it and pass it straight in:
+
+```tsx
+const recipe: UserAvatarFragment = {
+  name: "Ada",
+  email: "ada@example.com",
+  imageUrl: null,
+};
+
+render(<UserAvatar user={recipe} />);
+```
+
+**Component runs its own `useQuery`/`useMutation`, or reads from
+`ROOT_QUERY`** (e.g. `SendToPlan`) — wrap it in `MockedProvider` from
+`@apollo/client/testing/react`. Mocks are request/variable → result pairs,
+matched against the actual operations the component fires:
+
+```tsx
+render(
+  <MockedProvider
+    mocks={[
+      {
+        request: { query: DoSendToPlanDocument, variables: { recipeId, planId } },
+        result: { data: { library: { sendRecipeToPlan: { id: "1" } } } },
+      },
+    ]}
+  >
+    <SendToPlan recipeId={recipeId} activePlanId={planId} />
+  </MockedProvider>,
+);
+```
+
+If a component reads a fragment `from: "ROOT_QUERY"` (data some ancestor
+query would normally have already put in the cache), seed that directly with
+`cache.writeFragment({ id: "ROOT_QUERY", fragment, fragmentName, variables, data })`
+on a cache passed via `MockedProvider`'s `cache` prop — see the worked
+example.
+
+We're not using msw (nothing needs network-level mocking yet — everything
+goes through Apollo) or codegen'd mock data (unnecessary indirection at this
+size). Revisit if either need becomes real.
+
+## File location and naming
+
+Co-located, matching the filename under test: `index.tsx` → `index.test.tsx`.
+This tightens (doesn't replace) the existing "`*.test.tsx` anywhere" rule in
+`CLAUDE.md` into an actual convention.
+
+## Coverage threshold
+
+None enforced yet. `pnpm run test:coverage` stays a visibility tool —
+enforcing a number against a near-empty suite would be meaningless. Revisit
+once more features have real tests.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@tailwindcss/postcss": "~4.1.11",
     "@testing-library/jest-dom": "~6.6.4",
     "@testing-library/react": "~16.3.0",
+    "@testing-library/user-event": "^14.6.5",
     "@types/node": "~20.19.9",
     "@types/react": "~19.1.9",
     "@types/react-dom": "~19.1.7",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "possible-types": "node scripts/build_possible_types.js http://localhost:8080/graphql src/lib/apollo/possible-types.ts",
     "postpossible-types": "prettier src/lib/apollo/possible-types.ts --write",
     "start": "node .next/standalone/server.js",
+    "pretest": "pnpm run generate",
     "test": "vitest",
+    "pretest:coverage": "pnpm run generate",
     "test:coverage": "vitest run --coverage",
     "pretsc": "pnpm run generate",
     "tsc": "tsc --noEmit"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@testing-library/react':
         specifier: ~16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/user-event':
+        specifier: ^14.6.5
+        version: 14.6.5(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ~20.19.9
         version: 20.19.11
@@ -2271,6 +2274,12 @@ packages:
 
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@testing-library/user-event@14.6.5':
+    resolution: {integrity: sha512-FhqjldLTpteueBaKflhNFlMT3+PM0O5fiBUivht6b9CZ1eesJyy7+g3Jr7XwJzt/Hip3ZG5hWwK1MX1FuDiE4w==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
@@ -8056,6 +8065,10 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@testing-library/user-event@14.6.5(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@theguild/federation-composition@0.19.1(graphql@16.11.0)':
     dependencies:
       constant-case: 3.0.4
@@ -8308,7 +8321,7 @@ snapshots:
   '@vitest/browser@3.2.4(vite@7.1.4(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@testing-library/user-event': 14.6.5(@testing-library/dom@10.4.1)
       '@vitest/mocker': 3.2.4(vite@7.1.4(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.18

--- a/src/features/send-to-plan/index.test.tsx
+++ b/src/features/send-to-plan/index.test.tsx
@@ -1,0 +1,77 @@
+import { buildInMemoryCache } from "@/lib/apollo/build-in-memory-cache";
+import { MockedProvider, MockedProviderProps } from "@apollo/client/testing/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { DoSendToPlanDocument } from "./__generated__/doSendToPlan.generated";
+import { SendToPlanFragmentDoc } from "./__generated__/sendToPlan.generated";
+import { SendToPlan } from "./index";
+
+const activePlanId = "plan-1";
+const recipeId = "recipe-1";
+
+function renderSendToPlan(mocks: MockedProviderProps["mocks"] = []) {
+  const cache = buildInMemoryCache();
+  // SendToPlan reads its fragment from ROOT_QUERY rather than a prop,
+  // mirroring how the planner screen's query would have already populated
+  // the cache. Seed it directly via the same fragment doc.
+  cache.writeFragment({
+    id: "ROOT_QUERY",
+    fragment: SendToPlanFragmentDoc,
+    fragmentName: "sendToPlan",
+    variables: { activePlanId },
+    data: {
+      planner: {
+        __typename: "PlannerQuery",
+        plan: { __typename: "Plan", id: activePlanId, name: "This Week" },
+      },
+    },
+  });
+
+  return render(
+    <MockedProvider cache={cache} mocks={mocks}>
+      <SendToPlan recipeId={recipeId} activePlanId={activePlanId} />
+    </MockedProvider>,
+  );
+}
+
+describe("SendToPlan", () => {
+  it("shows the active plan's name", () => {
+    renderSendToPlan();
+
+    expect(
+      screen.getByRole("button", { name: /this week/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("sends the recipe to the plan when clicked", async () => {
+    const user = userEvent.setup();
+
+    renderSendToPlan([
+      {
+        request: {
+          query: DoSendToPlanDocument,
+          variables: { recipeId, planId: activePlanId },
+        },
+        result: {
+          data: {
+            library: {
+              __typename: "LibraryMutation",
+              sendRecipeToPlan: { __typename: "PlanItem", id: "item-1" },
+            },
+          },
+        },
+      },
+    ]);
+
+    await user.click(screen.getByRole("button", { name: /this week/i }));
+
+    expect(
+      screen.getByRole("button", { name: /sending/i }),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByRole("button", { name: /this week/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/send-to-plan/index.test.tsx
+++ b/src/features/send-to-plan/index.test.tsx
@@ -1,5 +1,8 @@
 import { buildInMemoryCache } from "@/lib/apollo/build-in-memory-cache";
-import { MockedProvider, MockedProviderProps } from "@apollo/client/testing/react";
+import {
+  MockedProvider,
+  MockedProviderProps,
+} from "@apollo/client/testing/react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";

--- a/src/test/dummy.test.tsx
+++ b/src/test/dummy.test.tsx
@@ -1,5 +1,0 @@
-import { expect, test } from "vitest";
-
-test("adds 1 + 2 to equal 3", () => {
-  expect(1 + 2).toBe(3);
-});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: "jsdom",
     exclude: [...configDefaults.exclude],
     globals: true,
-    include: ["./**/*.test.tsx"],
+    include: ["./**/*.test.{ts,tsx}"],
     setupFiles: "./src/test/setup.ts",
   },
   resolve: {


### PR DESCRIPTION
## Summary
- Documents feature-code testing conventions in `docs/testing.md`: coverage expectations (render tests + behavior tests for critical interactions), GraphQL mocking via Apollo `MockedProvider`, co-located `*.test.{ts,tsx}` naming, and explicit guidance for AI-authored tests (no tautological tests, real assertions, typed/realistic mocks)
- Adds a worked example (`src/features/send-to-plan/index.test.tsx`) covering both a render test and a click → mutation → loading-state behavior test
- Fixes `vitest.config.ts`'s `include` glob, which was `.tsx`-only and would have silently skipped pure-logic `.test.ts` files
- Adds `@testing-library/user-event`, removes the now-redundant placeholder test

Closes [BFS-33](https://linear.app/go-brennas/issue/BFS-33/define-testing-conventions-for-feature-code). Feeds into BFS-31 (finalizing CLAUDE.md across all Steel Thread convention tickets).

## Test plan
- [x] `pnpm test` — full suite passes
- [x] `pnpm run lint` — no warnings
- [x] `pnpm run tsc` — no type errors
- [x] Verified the vitest glob fix by temporarily adding a `.test.ts` file and confirming it ran